### PR TITLE
Project Controls Improvement

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -49,7 +49,7 @@
 }
 
 .projects_modal .project.hover .project-holder{
-    margin-left: 118px;
+   /* Removed Margin on the Left */
 }
 
 .projects_modal .project.hover .brproj{
@@ -89,6 +89,7 @@
     transition: 0.25s all;
     margin-top: 5px;
     color: gray;
+    float: right; /* Moving the Controls to the Right */
 }
 
 .projects_modal .projects .brproj:hover,


### PR DESCRIPTION
Moved the control to the right for better experience.
The controls should not be obstruct the usage, on the left they moved over the project causing accidental clicks on the controls (example: remove project...).
This way it should provide a better experience with less misclicks.
